### PR TITLE
Treat nil being passed as parameter.

### DIFF
--- a/lib/email_checker.ex
+++ b/lib/email_checker.ex
@@ -24,6 +24,7 @@ defmodule EmailChecker do
   """
   @spec valid?(String.t, [EmailChecker.Check]) :: boolean
   def valid?(email, validations \\ configured_validations())
+  def valid?(nil, _validations), do: false
   def valid?(email, [validation | tail]) do
     if validation.valid?(email) do
       valid?(email, tail)

--- a/test/email_checker_test.exs
+++ b/test/email_checker_test.exs
@@ -30,4 +30,8 @@ defmodule EmailCheckerTest do
     Application.put_env(:email_checker, :validations, [EmailChecker.Check.Format])
     assert true == EmailChecker.valid?("derp@asdf.com")
   end
+
+  test "valid?: nil email" do
+    assert false == EmailChecker.valid?(nil)
+  end
 end

--- a/test/email_checker_test.exs
+++ b/test/email_checker_test.exs
@@ -32,6 +32,6 @@ defmodule EmailCheckerTest do
   end
 
   test "valid?: nil email" do
-    assert false == EmailChecker.valid?(nil)
+    refute EmailChecker.valid?(nil)
   end
 end


### PR DESCRIPTION
Addressing #7 when passing `nil` as a parameter to `EmailChecker.valid?/1`.