### PR TITLE
HELO doesn't work with empty message

### DIFF
--- a/lib/email_checker/check/smtp.ex
+++ b/lib/email_checker/check/smtp.ex
@@ -39,6 +39,11 @@ defmodule EmailChecker.Check.SMTP do
       valid?(email, retries - 1)
   end
 
+  defp domain_name(email) do
+    email
+    |> Tools.domain_name
+  end
+
   defp mx_address(email) do
     email
     |> Tools.domain_name
@@ -62,7 +67,7 @@ defmodule EmailChecker.Check.SMTP do
       |> TCP.connect!(25, opts)
     socket |> Stream.recv!
 
-    socket |> Stream.send!("HELO\r\n")
+    socket |> Stream.send!("HELO #{domain_name(email)}\r\n")
     socket |> Stream.recv!
 
     socket |> Stream.send!("mail from:<fake@email.com>\r\n")


### PR DESCRIPTION
Hello! 

It seems that HELO/EHLO doesn't work with empty message, and it asks for domain name, according to Microsoft docs :)
https://technet.microsoft.com/en-us/library/aa995718(v=exchg.65).aspx

here's screenshot with the error
![screen shot 2018-02-06 at 21 54 47](https://user-images.githubusercontent.com/4546045/35878561-ba8f36f6-0b89-11e8-87df-acdd30d3459d.png)