### PR TITLE
Fix compiler warning for deprecated function

### DIFF
--- a/lib/email_checker/tools.ex
+++ b/lib/email_checker/tools.ex
@@ -29,7 +29,7 @@ defmodule EmailChecker.Tools do
 
   defp lookup_all(domain_name) do
     domain_name
-    |> String.to_char_list()
+    |> String.to_charlist()
     |> :inet_res.lookup(:in, :mx, [], max_timeout())
     |> normalize_mx_records_to_string
   end


### PR DESCRIPTION
`String.to_charlist/1` has been available since Elixir 1.3.0 which is the minimum required version for this library anyway.