### PR TITLE
Return false for nonexistent domain in SMTP check

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ end
 def deps do
   [
     # other dependencies...
-    {:email_checker, "~> 0.1.2"}
+    {:email_checker, "~> 0.2.1"}
     # other dependencies...
   ]
 end

--- a/lib/email_checker/check/smtp.ex
+++ b/lib/email_checker/check/smtp.ex
@@ -39,6 +39,9 @@ if match?({:module, Socket.TCP}, Code.ensure_compiled(Socket.TCP)) do
     rescue
       Socket.Error ->
         valid?(email, retries - 1)
+
+      _ ->
+        false
     end
 
     defp mx_address(email) do


### PR DESCRIPTION
I added a default false return for SMTP checks if the domain is non-existent OR if the request fails for anything other than a `Socket.Error`.