### PR TITLE
Update README for modern Mix practices

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,20 +21,10 @@ all emails using this domain seems valid even if they are not.
 
 ```elixir
 # mix.exs
-def application do
-  [mod: {YourModule, []},
-   applications: [
-     # other applications...
-     :email_checker,
-     # other applications...
-     ]
-  ]
-end
-
 def deps do
   [
     # other dependencies...
-    {:email_checker, "~> 0.1.2"}
+    {:email_checker, "~> 0.2.4"}
     # other dependencies...
   ]
 end


### PR DESCRIPTION
Since https://github.com/elixir-lang/elixir/pull/5473 in Elixir 1.4, the `applications` key is automatically populated by Mix based on `deps` - but ONLY if it's not manually specified in `mix.exs`.

Adding an explicit `applications` key leads to user confusion, since other dependencies that were expecting to be automatically started won't be.

Also updates the example version to match the latest release.